### PR TITLE
Class transform: Fix super calls and literal methods

### DIFF
--- a/src/utils.js
+++ b/src/utils.js
@@ -53,6 +53,11 @@ function createState(source, rootNode, transformOptions) {
      */
     mungeNamespace: '',
     /**
+     * Ref to the node for the current MethodDefinition
+     * @type {Object}
+     */
+    methodNode: null,
+    /**
      * Ref to the node for the FunctionExpression of the enclosing
      * MethodDefinition
      * @type {Object}

--- a/visitors/__tests__/es6-class-visitors-test.js
+++ b/visitors/__tests__/es6-class-visitors-test.js
@@ -151,7 +151,7 @@ describe('es6-classes', function() {
           '  Foo.prototype.foo=function() {"use strict";',
           '    ',
           '    ',
-          '    Bar.call(this,p1,',
+          '    ____SuperProtoOfBar.foo.call(this,p1,',
           '          p2);',
           '  };',
           '',
@@ -448,17 +448,23 @@ describe('es6-classes', function() {
       it('handles super CallExpressions within proto methods', function() {
         var code = transform([
           'class Parent {',
-          '  constructor(p1, p2) {',
+          '  bar(p1, p2) {',
           '    this.p1 = p1;',
           '    this.p2 = p2;',
+          '  }',
+          '  "baz qux"(p3) {',
+          '    this.p3 = p3;',
           '  }',
           '}',
 
           'class Child extends Parent {',
-          '  constructor() {}',
           '  bar() {',
           '    super("a", "b");',
           '    this.barRan = true;',
+          '  }',
+          '  "baz qux"() {',
+          '    super("c");',
+          '    this["baz qux run"] = true;',
           '  }',
           '}'
         ].join('\n'));
@@ -469,10 +475,18 @@ describe('es6-classes', function() {
         expect(childInst.p1).toBe(undefined);
         expect(childInst.p2).toBe(undefined);
         expect(childInst.barRan).toBe(undefined);
+
         childInst.bar();
         expect(childInst.p1).toBe('a');
         expect(childInst.p2).toBe('b');
         expect(childInst.barRan).toBe(true);
+
+        expect(childInst.p3).toBe(undefined);
+        expect(childInst['baz qux run']).toBe(undefined);
+
+        childInst['baz qux']();
+        expect(childInst.p3).toBe('c');
+        expect(childInst['baz qux run']).toBe(true);
       });
 
       it('handles computed super MemberExpressions',
@@ -1075,7 +1089,7 @@ describe('es6-classes', function() {
           '  ____Class0.prototype.foo=function() {"use strict";',
           '    ',
           '    ',
-          '    Bar.call(this,p1,',
+          '    ____SuperProtoOfBar.foo.call(this,p1,',
           '          p2);',
           '  };',
           '',


### PR DESCRIPTION
This diff fixed two things:

1. Unqualified super calls from methods should call [1] parent methods with the same name (the bug was: they called parent constructor);

```
class A {
  foo() { console.log('A#foo'); }
}

class B extends A {
  // This method should call A#foo
  foo() { super(); }
}
```
[1] http://people.mozilla.org/~jorendorff/es6-draft.html#sec-makesuperreference

2. Fixed literal method names (the bug was: method name was compiled as `undefined`)

```
class A {
  'foo bar'() {}
}
```