### PR TITLE
Make type aliases exportable.

### DIFF
--- a/visitors/__tests__/gen/type-syntax-test.rec.js
+++ b/visitors/__tests__/gen/type-syntax-test.rec.js
@@ -412,13 +412,13 @@ module.exports = {
     'Type Alias': {
         'type FBID = number;': {
             raworiginal: 'type FBID = number;',
-            transformed: '                   ',
+            transformed: 'var FBID;                   ',
             eval: 'No error',
 
         },
         'type Foo<T> = Bar<T>': {
             raworiginal: 'type Foo<T> = Bar<T>',
-            transformed: '                    ',
+            transformed: 'var Foo;                    ',
             eval: 'No error',
 
         },

--- a/visitors/__tests__/type-alias-syntax-test.js
+++ b/visitors/__tests__/type-alias-syntax-test.js
@@ -46,7 +46,7 @@ describe('static type syntax syntax', function() {
   }
 
   describe('type alias', () => {
-    it('strips type aliases', () => {
+    it('ignores type aliases', () => {
       /*global type*/
       var code = transform([
         'var type = 42;',
@@ -56,6 +56,14 @@ describe('static type syntax syntax', function() {
       ]);
       eval(code);
       expect(type).toBe(84);
+    });
+    it('allows export of type aliases', () => {
+      var code = transform([
+        'type FBID = number;',
+        'exports.FBID = FBID;',
+      ]);
+      eval(code);
+      expect(exports.FBID).toBe(void 0);
     });
   });
 });

--- a/visitors/type-syntax.js
+++ b/visitors/type-syntax.js
@@ -19,6 +19,7 @@ visitClassProperty.test = function(node, path, state) {
 };
 
 function visitTypeAlias(traverse, node, path, state) {
+  utils.append('var ' + node.id.name + ';', state);
   utils.catchupWhiteOut(node.range[1], state);
   return false;
 }


### PR DESCRIPTION
Hack: generates empty var declarations for type aliases. Flow users
should now be able to attach types to the exports object without it
resulting with errors being thrown.