### PR TITLE
Add support for computed class methods

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
   ],
   "dependencies": {
     "base62": "0.1.1",
-    "esprima-fb": "8001.1001.0-dev-harmony-fb",
+    "esprima-fb": "10001.1.0-dev-harmony-fb",
     "source-map": "0.1.31"
   },
   "licenses": [

--- a/visitors/__tests__/es6-class-visitors-test.js
+++ b/visitors/__tests__/es6-class-visitors-test.js
@@ -1251,6 +1251,37 @@ describe('es6-classes', function() {
           '(line: 2, col: 2)'
         );
       });
+
+      it('properly handles computed static methods', function() {
+        var code = transform([
+          'var bar = "foobar";',
+          'class Foo {',
+          '  static [bar]() {',
+          '    return 42;',
+          '  }',
+          '}'
+        ].join('\n'));
+
+        eval(code);
+
+        expect(Foo.foobar()).toBe(42);
+      });
+
+      it('properly handles computed instance methods', function() {
+        var code = transform([
+          'var bar = "foobar";',
+          'class Foo {',
+          '  [bar]() {',
+          '    return 42;',
+          '  }',
+          '}'
+        ].join('\n'));
+
+        eval(code);
+
+        var fooInst = new Foo();
+        expect(fooInst.foobar()).toBe(42);
+      });
     });
   });
 

--- a/visitors/es6-class-visitors.js
+++ b/visitors/es6-class-visitors.js
@@ -181,7 +181,7 @@ function visitClassFunctionExpression(traverse, node, path, state) {
   if (methodNode.key.name === 'constructor') {
     utils.append('function ' + state.className, state);
   } else {
-    var methodAccessorComputed = false;
+    var methodAccessorComputed = methodNode.computed;
     var methodAccessor;
     var prototypeOrStatic = methodNode.static ? '' : '.prototype';
     var objectAccessor = state.className + prototypeOrStatic;


### PR DESCRIPTION
This also bumps `esprima-fb` to the latest as the previous version didn't set the `computed` property, not sure what else will be effected by this change.