### PR TITLE
Inject temporary variables at start of scope.

### DIFF
--- a/src/__tests__/jstransform-utils-test.js
+++ b/src/__tests__/jstransform-utils-test.js
@@ -16,6 +16,8 @@
  * @emails jeffmo@fb.com
  */
 
+/*jshint evil:true*/
+
 require('mock-modules').autoMockOff();
 
 describe('jstransform-utils', function() {

--- a/src/__tests__/jstransform-utils-test.js
+++ b/src/__tests__/jstransform-utils-test.js
@@ -1,0 +1,64 @@
+/**
+ * Copyright 2013 Facebook, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * @emails jeffmo@fb.com
+ */
+
+require('mock-modules').autoMockOff();
+
+describe('jstransform-utils', function() {
+  var transform, utils;
+  var Syntax = require('esprima-fb').Syntax;
+
+  beforeEach(function() {
+    require('mock-modules').dumpCache();
+    transform = require('../jstransform').transform;
+    utils = require('../utils');
+  });
+
+  describe('temporary variables', function() {
+    it('should inject temporary variables at the start of functions', function() {
+      function visitFunctionBlock(traverse, node, path, state) {
+        utils.catchup(node.range[0] + 1, state);
+        var x = utils.injectTempVar(state);
+        var y = utils.injectTempVar(state);
+        traverse(node.body, path, state);
+        utils.append('return ' + x + ' + ' + y + ';', state);
+        utils.catchup(node.range[1], state);
+        return false;
+      }
+      visitFunctionBlock.test = function(node, path, state) {
+        var parentType = path.length && path[0].type;
+        return node.type === Syntax.BlockStatement && (
+          parentType === Syntax.FunctionDeclaration ||
+          parentType === Syntax.FunctionExpression
+        );
+      };
+
+      expect(transform(
+        [visitFunctionBlock],
+        'var x = function() {};'
+      ).code).toEqual(
+        'var x = function() {var $__0, $__1;return $__0 + $__1;};'
+      );
+
+      expect(eval(transform(
+        [visitFunctionBlock],
+        '2 + (function sum(x, y)\t{ $__0 = x; $__1 = y; }(3, 5))'
+      ).code)).toEqual(10);
+    });
+  });
+
+});

--- a/src/utils.js
+++ b/src/utils.js
@@ -42,7 +42,8 @@ function createState(source, rootNode, transformOptions) {
       parentNode: rootNode,
       parentScope: null,
       identifiers: {},
-      tempVarIndex: 0
+      tempVarIndex: 0,
+      tempVars: []
     },
     /**
      * The name (and, if applicable, expression) of the super class
@@ -661,8 +662,20 @@ function getTempVar(tempVarIndex) {
   return '$__' + tempVarIndex;
 }
 
-function getTempVarWithValue(tempVarIndex, tempVarValue) {
-  return getTempVar(tempVarIndex) + '=' + tempVarValue;
+function injectTempVar(state) {
+  var tempVar = '$__' + (state.localScope.tempVarIndex++);
+  state.localScope.tempVars.push(tempVar);
+  return tempVar;
+}
+
+function injectTempVarDeclarations(state, index) {
+  if (state.localScope.tempVars.length) {
+    state.g.buffer =
+      state.g.buffer.slice(0, index) +
+      'var ' + state.localScope.tempVars.join(', ') + ';' +
+      state.g.buffer.slice(index);
+    state.localScope.tempVars = [];
+  }
 }
 
 exports.analyzeAndTraverse = analyzeAndTraverse;
@@ -683,11 +696,12 @@ exports.getNextSyntacticCharOffset = getNextSyntacticCharOffset;
 exports.getNodeSourceText = getNodeSourceText;
 exports.getOrderedChildren = getOrderedChildren;
 exports.getTempVar = getTempVar;
-exports.getTempVarWithValue = getTempVarWithValue;
 exports.identInLocalScope = identInLocalScope;
 exports.identWithinLexicalScope = identWithinLexicalScope;
 exports.indentBefore = indentBefore;
 exports.initScopeMetadata = initScopeMetadata;
+exports.injectTempVar = injectTempVar;
+exports.injectTempVarDeclarations = injectTempVarDeclarations;
 exports.move = move;
 exports.scopeTypes = scopeTypes;
 exports.updateIndent = updateIndent;

--- a/visitors/es6-destructuring-visitors.js
+++ b/visitors/es6-destructuring-visitors.js
@@ -119,7 +119,7 @@ function getDestructuredComponents(node, state) {
     } else {
       // Complex sub-structure.
       components.push(
-        utils.getTempVarWithValue(++state.localScope.tempVarIndex, accessor) +
+        utils.getTempVar(++state.localScope.tempVarIndex) + '=' + accessor +
         ',' + getDestructuredComponents(value, state)
       );
     }

--- a/visitors/es6-rest-param-visitors.js
+++ b/visitors/es6-rest-param-visitors.js
@@ -80,8 +80,8 @@ function renderRestParamSetup(functionNode, state) {
   var len = state.localScope.tempVarIndex++;
 
   return 'for (var ' + functionNode.rest.name + '=[],' +
-    utils.getTempVarWithValue(idx, functionNode.params.length) + ',' +
-    utils.getTempVarWithValue(len, 'arguments.length') + ';' +
+    utils.getTempVar(idx) + '=' + functionNode.params.length + ',' +
+    utils.getTempVar(len) + '=arguments.length;' +
     utils.getTempVar(idx) + '<' +  utils.getTempVar(len) + ';' +
     utils.getTempVar(idx) + '++) ' +
     functionNode.rest.name + '.push(arguments[' + utils.getTempVar(idx) + ']);';


### PR DESCRIPTION
Adding new functions to `utils.js` to allow creating new temporary variables, which will automatically be injected into the buffer once the current scope ends. This will allow us to introduce more complex transforms like the call spread operator.