### PR TITLE
Stop Quoting `await` Identifier Names

### DIFF
--- a/visitors/__tests__/reserved-words-test.js
+++ b/visitors/__tests__/reserved-words-test.js
@@ -50,13 +50,25 @@ describe('reserved-words', function() {
 
       expect(transform(code)).toEqual('foo["return"]();');
     });
+
+    it('should only quote ES3 reserved words', function() {
+      var code = 'foo.await();';
+
+      expect(transform(code)).toEqual('foo.await();');
+    });
   });
 
   describe('reserved words in properties', function() {
-    it('should qoute reserved words in properties', function() {
+    it('should quote reserved words in properties', function() {
       var code = 'var x = {null: 1};';
 
       expect(transform(code)).toEqual('var x = {"null": 1};');
+    });
+
+    it('should only quote ES3 reserved words', function() {
+      var code = 'var x = {await: 1};';
+
+      expect(transform(code)).toEqual('var x = {await: 1};');
     });
   });
 });

--- a/visitors/reserved-words-helper.js
+++ b/visitors/reserved-words-helper.js
@@ -44,6 +44,31 @@ RESERVED_WORDS.forEach(function(k) {
     reservedWordsMap[k] = true;
 });
 
+/**
+ * This list should not grow as new reserved words are introdued. This list is
+ * of words that need to be quoted because ES3-ish browsers do not allow their
+ * use as identifier names.
+ */
+var ES3_FUTURE_RESERVED_WORDS = [
+  'enum', 'implements', 'package', 'protected', 'static', 'interface',
+  'private', 'public'
+];
+
+var ES3_RESERVED_WORDS = [].concat(
+  KEYWORDS,
+  ES3_FUTURE_RESERVED_WORDS,
+  LITERALS
+);
+
+var es3ReservedWordsMap = Object.create(null);
+ES3_RESERVED_WORDS.forEach(function(k) {
+    es3ReservedWordsMap[k] = true;
+});
+
 exports.isReservedWord = function(word) {
   return !!reservedWordsMap[word];
+};
+
+exports.isES3ReservedWord = function(word) {
+  return !!es3ReservedWordsMap[word];
 };

--- a/visitors/reserved-words-visitors.js
+++ b/visitors/reserved-words-visitors.js
@@ -42,7 +42,7 @@ visitProperty.test = function(node) {
     !node.method &&
     !node.shorthand &&
     !node.computed &&
-    reserverdWordsHelper.isReservedWord(node.key.name);
+    reserverdWordsHelper.isES3ReservedWord(node.key.name);
 };
 
 function visitMemberExpression(traverse, node, path, state) {
@@ -59,7 +59,7 @@ function visitMemberExpression(traverse, node, path, state) {
 visitMemberExpression.test = function(node) {
   return node.type === Syntax.MemberExpression &&
     node.property.type === Syntax.Identifier &&
-    reserverdWordsHelper.isReservedWord(node.property.name);
+    reserverdWordsHelper.isES3ReservedWord(node.property.name);
 };
 
 exports.visitorList = [


### PR DESCRIPTION
Summary:
We have a transform that quotes future reserved words so that ES3-ish browsers (e.g. IE 8) don't choke on them.

Although `await` is now a future reserved word, it was not introduced until ES6. This means older browsers (e.g. IE 8) can treat them as normal identifier names just fine.

Test Plan:
Verified that the following runs in IE 8:

  var object = {await: 42};
  object.await === 42;

Reviewers: @jeffmo