### PR TITLE
Fix type cast visitor to visit expression

### DIFF
--- a/visitors/__tests__/gen/type-syntax-test.rec.js
+++ b/visitors/__tests__/gen/type-syntax-test.rec.js
@@ -824,5 +824,11 @@ module.exports = {
             eval: 'xxx is not defined',
 
         },
+        '((xxx: any): number)': {
+            raworiginal: '((xxx: any): number)',
+            transformed: '((xxx     )        )',
+            eval: 'xxx is not defined',
+
+        },
     },
 };

--- a/visitors/__tests__/type-syntax-test.js
+++ b/visitors/__tests__/type-syntax-test.js
@@ -159,6 +159,7 @@ if (!!module.parent) {
         '((xxx) => xxx + 1: (xxx: number) => number)',
         // parens disambiguate groups from casts
         '((xxx: number), (yyy: string))',
+        '((xxx: any): number)',
     ],
   };
 } else {

--- a/visitors/type-syntax.js
+++ b/visitors/type-syntax.js
@@ -27,6 +27,10 @@ visitTypeAlias.test = function(node, path, state) {
 };
 
 function visitTypeCast(traverse, node, path, state) {
+  path.unshift(node);
+  traverse(node.expression, path, state);
+  path.shift();
+
   utils.catchup(node.typeAnnotation.range[0], state);
   utils.catchupWhiteOut(node.typeAnnotation.range[1], state);
   return false;


### PR DESCRIPTION
Expressions like `((xxx: any): number)` were being transformed to `((xxx: any)        )` since we weren't visiting the inner expression.