### PR TITLE
Use "Object.assign" to copy class static props

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,13 @@ A simple utility for pluggable JS syntax transforms using the esprima parser.
 
 NOTE: If you're looking for a library for writing new greenfield JS transformations, consider looking at the  [Recast](https://github.com/benjamn/recast) library instead of jstransform. We are still actively supporting jstransform (and intend to for the foreseeable future), but longer term we would like to direct efforts toward Recast. Recast does a far better job of supporting a multi-pass JS transformation pipeline, and this is important when attempting to apply many transformations to a source file.
 
+## Polyfill requirements
+
+| Transform | [`Object.assign`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object/assign) |
+| ----------| :-------------: |
+| `class` | **X** |
+| Spread properties | **X** |
+
 ## Examples
 Using a pre-bundled or existing transform:
 ```js

--- a/visitors/__tests__/es6-class-visitors-test.js
+++ b/visitors/__tests__/es6-class-visitors-test.js
@@ -148,11 +148,7 @@ describe('es6-classes', function() {
         ].join('\n');
 
         var expected = [
-          'for(var Bar____Key in Bar){' +
-            'if(Bar.hasOwnProperty(Bar____Key)){' +
-              'Foo[Bar____Key]=Bar[Bar____Key];' +
-            '}' +
-          '}' +
+          'Object.assign(Foo,Bar);' +
           'var ____SuperProtoOfBar=' +
             'Bar===null' +
               '?null:' +
@@ -209,11 +205,7 @@ describe('es6-classes', function() {
 
         var expected = [
           'var ____Class0=mixin(Bar, Baz);' +
-          'for(var ____Class0____Key in ____Class0){' +
-            'if(____Class0.hasOwnProperty(____Class0____Key)){' +
-              'Foo[____Class0____Key]=____Class0[____Class0____Key];' +
-            '}' +
-          '}' +
+          'Object.assign(Foo,____Class0);' +
           'var ____SuperProtoOf____Class0=' +
             '____Class0===null' +
               '?null' +
@@ -1327,11 +1319,7 @@ describe('es6-classes', function() {
 
         var expected = [
           'var Foo = (function(){' +
-          'for(var Bar____Key in Bar){' +
-            'if(Bar.hasOwnProperty(Bar____Key)){' +
-              '____Class0[Bar____Key]=Bar[Bar____Key];' +
-            '}' +
-          '}' +
+          'Object.assign(____Class0,Bar);' +
           'var ____SuperProtoOfBar=' +
             'Bar===null' +
               '?null' +
@@ -1389,11 +1377,7 @@ describe('es6-classes', function() {
         var expected = [
           'var Foo = (function(){' +
           'var ____Class1=mixin(Bar, Baz);' +
-          'for(var ____Class1____Key in ____Class1){' +
-            'if(____Class1.hasOwnProperty(____Class1____Key)){' +
-              '____Class0[____Class1____Key]=____Class1[____Class1____Key];' +
-            '}' +
-          '}' +
+          'Object.assign(____Class0,____Class1);' +
           'var ____SuperProtoOf____Class1=' +
             '____Class1===null' +
               '?null' +

--- a/visitors/__tests__/es6-class-visitors-test.js
+++ b/visitors/__tests__/es6-class-visitors-test.js
@@ -148,7 +148,11 @@ describe('es6-classes', function() {
         ].join('\n');
 
         var expected = [
-          'Object.assign(Foo,Bar);' +
+          'for(var Bar____Key in Bar){' +
+            'if(Bar.hasOwnProperty(Bar____Key)){' +
+              'Foo[Bar____Key]=Bar[Bar____Key];' +
+            '}' +
+          '}' +
           'var ____SuperProtoOfBar=' +
             'Bar===null' +
               '?null:' +
@@ -182,7 +186,124 @@ describe('es6-classes', function() {
         expect(transform(code)).toBe(expected);
       });
 
+      it('preserves lines with inheritance from identifier (polyfilled)', function() {
+        var code = [
+          'class Foo extends Bar {',
+          '  foo() {',
+          '    ',
+          '    ',
+          '    super(p1,',
+          '          p2);',
+          '  }',
+          '',
+          '  constructor(p1,',
+          '              p2) {',
+          '',
+          '    this.p1 = p1;',
+          '    this.p2 = p2;',
+          '    super.blah(p1,',
+          '               p2);',
+          '  }',
+          '',
+          '  bar(){}',
+          '  static baz() {',
+          '}',
+          '}'
+        ].join('\n');
+
+        var expected = [
+          'Object.assign(Foo,Bar);' +
+          'var ____SuperProtoOfBar=' +
+            'Bar===null' +
+              '?null:' +
+              'Bar.prototype;' +
+          'Foo.prototype=Object.create(____SuperProtoOfBar);' +
+          'Foo.prototype.constructor=Foo;' +
+          'Foo.__superConstructor__=Bar;',
+
+          '  Object.defineProperty(Foo.prototype,"foo",{writable:true,configurable:true,value:function() {"use strict";',
+          '    ',
+          '    ',
+          '    ____SuperProtoOfBar.foo.call(this,p1,',
+          '          p2);',
+          '  }});',
+          '',
+          '  function Foo(p1,',
+          '              p2) {"use strict";',
+          '',
+          '    this.p1 = p1;',
+          '    this.p2 = p2;',
+          '    ____SuperProtoOfBar.blah.call(this,p1,',
+          '               p2);',
+          '  }',
+          '',
+          '  Object.defineProperty(Foo.prototype,"bar",{writable:true,configurable:true,value:function(){"use strict";}});',
+          '  Object.defineProperty(Foo,"baz",{writable:true,configurable:true,value:function() {"use strict";',
+          '}});',
+          ''
+        ].join('\n');
+
+        expect(transform(code, {polyfilled: true})).toBe(expected);
+      });
+
       it('preserves lines with inheritance from expression', function() {
+        var code = [
+          'class Foo extends mixin(Bar, Baz) {',
+          '  foo() {',
+          '    ',
+          '    ',
+          '  }',
+          '',
+          '  constructor(p1,',
+          '              p2) {',
+          '',
+          '    this.p1 = p1;',
+          '    this.p2 = p2;',
+          '  }',
+          '',
+          '  bar(){}',
+          '  static baz() {',
+          '}',
+          '}'
+        ].join('\n');
+
+        var expected = [
+          'var ____Class0=mixin(Bar, Baz);' +
+          'for(var ____Class0____Key in ____Class0){' +
+            'if(____Class0.hasOwnProperty(____Class0____Key)){' +
+              'Foo[____Class0____Key]=____Class0[____Class0____Key];' +
+            '}' +
+          '}' +
+          'var ____SuperProtoOf____Class0=' +
+            '____Class0===null' +
+              '?null' +
+              ':____Class0.prototype;' +
+          'Foo.prototype=Object.create(____SuperProtoOf____Class0);' +
+          'Foo.prototype.constructor=Foo;' +
+          'Foo.__superConstructor__=____Class0;',
+
+          '  Object.defineProperty(Foo.prototype,"foo",{writable:true,configurable:true,value:function() {"use strict";',
+          '    ',
+          '    ',
+          '  }});',
+          '',
+          '  function Foo(p1,',
+          '              p2) {"use strict";',
+          '',
+          '    this.p1 = p1;',
+          '    this.p2 = p2;',
+          '  }',
+          '',
+          '  Object.defineProperty(Foo.prototype,"bar",{writable:true,configurable:true,value:function(){"use strict";}});',
+          '  Object.defineProperty(Foo,"baz",{writable:true,configurable:true,value:function() {"use strict";',
+          '}});',
+          ''
+        ].join('\n');
+
+        expect(transform(code)).toBe(expected);
+      });
+
+      it('preserves lines with inheritance from expression (polyfilled)', function() {
         var code = [
           'class Foo extends mixin(Bar, Baz) {',
           '  foo() {',
@@ -232,9 +353,10 @@ describe('es6-classes', function() {
           ''
         ].join('\n');
 
-        expect(transform(code)).toBe(expected);
+        expect(transform(code, {polyfilled: true})).toBe(expected);
       });
     });
+
 
     describe('functional tests', function() {
       it('handles an empty body', function() {
@@ -368,6 +490,29 @@ describe('es6-classes', function() {
         expect(childInst.protoProp).toBe('protoProp');
       });
 
+      it('handles extension from an identifier (polyfilled)', function() {
+        var code = transform([
+          'function Parent() {}',
+          'Parent.prototype.protoProp = "protoProp";',
+          'Parent.staticProp = "staticProp";',
+
+          'class Child extends Parent {}'
+        ].join('\n'), {polyfilled: true});
+
+        var exports = new Function(
+          code + 'return {Child: Child, Parent: Parent};'
+        )();
+        var Child = exports.Child;
+        var Parent = exports.Parent;
+
+        expect(Child.protoProp).toBe(undefined);
+        expect(Child.staticProp).toBe('staticProp');
+        var childInst = new Child();
+        expect(childInst instanceof Child).toBe(true);
+        expect(childInst instanceof Parent).toBe(true);
+        expect(childInst.protoProp).toBe('protoProp');
+      });
+
       // ES6 draft section 14.5
       it('handles extension from a left hand expression', function() {
         var code = transform([
@@ -379,6 +524,32 @@ describe('es6-classes', function() {
 
           'class Child extends (true ? Parent1 : Parent2) {}'
         ].join('\n'));
+
+        var exports = new Function(
+          code + 'return {Parent1: Parent1, Child: Child};'
+        )();
+        var Child = exports.Child;
+        var Parent1 = exports.Parent1;
+
+        expect(Child.protoProp).toBe(undefined);
+        expect(Child.staticProp).toBe('staticProp');
+        var childInst = new Child();
+        expect(childInst instanceof Child).toBe(true);
+        expect(childInst instanceof Parent1).toBe(true);
+        expect(childInst.protoProp).toBe('protoProp');
+        expect(childInst.staticProp).toBe(undefined);
+      });
+
+      it('handles extension from a left hand expression (polyfilled)', function() {
+        var code = transform([
+          'function Parent1() {}',
+          'Parent1.prototype.protoProp = "protoProp";',
+          'Parent1.staticProp = "staticProp";',
+
+          'function Parent2() {}',
+
+          'class Child extends (true ? Parent1 : Parent2) {}'
+        ].join('\n'), {polyfilled: true});
 
         var exports = new Function(
           code + 'return {Parent1: Parent1, Child: Child};'
@@ -1319,7 +1490,11 @@ describe('es6-classes', function() {
 
         var expected = [
           'var Foo = (function(){' +
-          'Object.assign(____Class0,Bar);' +
+          'for(var Bar____Key in Bar){' +
+            'if(Bar.hasOwnProperty(Bar____Key)){' +
+              '____Class0[Bar____Key]=Bar[Bar____Key];' +
+            '}' +
+          '}' +
           'var ____SuperProtoOfBar=' +
             'Bar===null' +
               '?null' +
@@ -1353,7 +1528,126 @@ describe('es6-classes', function() {
         expect(transform(code)).toBe(expected);
       });
 
+      it('preserves lines with inheritance from identifier (polyfilled)', function() {
+        var code = [
+          'var Foo = class extends Bar {',
+          '  foo() {',
+          '    ',
+          '    ',
+          '    super(p1,',
+          '          p2);',
+          '  }',
+          '',
+          '  constructor(p1,',
+          '              p2) {',
+          '',
+          '    this.p1 = p1;',
+          '    this.p2 = p2;',
+          '    super.blah(p1,',
+          '               p2);',
+          '  }',
+          '',
+          '  bar(){}',
+          '  static baz() {',
+          '}',
+          '}'
+        ].join('\n');
+
+        var expected = [
+          'var Foo = (function(){' +
+          'Object.assign(____Class0,Bar);' +
+          'var ____SuperProtoOfBar=' +
+            'Bar===null' +
+              '?null' +
+              ':Bar.prototype;' +
+          '____Class0.prototype=Object.create(____SuperProtoOfBar);' +
+          '____Class0.prototype.constructor=____Class0;' +
+          '____Class0.__superConstructor__=Bar;',
+
+          '  Object.defineProperty(____Class0.prototype,"foo",{writable:true,configurable:true,value:function() {"use strict";',
+          '    ',
+          '    ',
+          '    ____SuperProtoOfBar.foo.call(this,p1,',
+          '          p2);',
+          '  }});',
+          '',
+          '  function ____Class0(p1,',
+          '              p2) {"use strict";',
+          '',
+          '    this.p1 = p1;',
+          '    this.p2 = p2;',
+          '    ____SuperProtoOfBar.blah.call(this,p1,',
+          '               p2);',
+          '  }',
+          '',
+          '  Object.defineProperty(____Class0.prototype,"bar",{writable:true,configurable:true,value:function(){"use strict";}});',
+          '  Object.defineProperty(____Class0,"baz",{writable:true,configurable:true,value:function() {"use strict";',
+          '}});',
+          'return ____Class0;})()'
+        ].join('\n');
+
+        expect(transform(code, {polyfilled: true})).toBe(expected);
+      });
+
       it('preserves lines with inheritance from expression', function() {
+        var code = [
+          'var Foo = class extends mixin(Bar, Baz) {',
+          '  foo() {',
+          '    ',
+          '    ',
+          '  }',
+          '',
+          '  constructor(p1,',
+          '              p2) {',
+          '',
+          '    this.p1 = p1;',
+          '    this.p2 = p2;',
+          '  }',
+          '',
+          '  bar(){}',
+          '  static baz() {',
+          '}',
+          '}'
+        ].join('\n');
+
+        var expected = [
+          'var Foo = (function(){' +
+          'var ____Class1=mixin(Bar, Baz);' +
+          'for(var ____Class1____Key in ____Class1){' +
+            'if(____Class1.hasOwnProperty(____Class1____Key)){' +
+              '____Class0[____Class1____Key]=____Class1[____Class1____Key];' +
+            '}' +
+          '}' +
+          'var ____SuperProtoOf____Class1=' +
+            '____Class1===null' +
+              '?null' +
+              ':____Class1.prototype;' +
+          '____Class0.prototype=Object.create(____SuperProtoOf____Class1);' +
+          '____Class0.prototype.constructor=____Class0;' +
+          '____Class0.__superConstructor__=____Class1;',
+
+          '  Object.defineProperty(____Class0.prototype,"foo",{writable:true,configurable:true,value:function() {"use strict";',
+          '    ',
+          '    ',
+          '  }});',
+          '',
+          '  function ____Class0(p1,',
+          '              p2) {"use strict";',
+          '',
+          '    this.p1 = p1;',
+          '    this.p2 = p2;',
+          '  }',
+          '',
+          '  Object.defineProperty(____Class0.prototype,"bar",{writable:true,configurable:true,value:function(){"use strict";}});',
+          '  Object.defineProperty(____Class0,"baz",{writable:true,configurable:true,value:function() {"use strict";',
+          '}});',
+          'return ____Class0;})()'
+        ].join('\n');
+
+        expect(transform(code)).toBe(expected);
+      });
+
+      it('preserves lines with inheritance from expression (polyfilled)', function() {
         var code = [
           'var Foo = class extends mixin(Bar, Baz) {',
           '  foo() {',
@@ -1404,7 +1698,7 @@ describe('es6-classes', function() {
           'return ____Class0;})()'
         ].join('\n');
 
-        expect(transform(code)).toBe(expected);
+        expect(transform(code, {polyfilled: true})).toBe(expected);
       });
     });
 

--- a/visitors/__tests__/es7-rest-property-helpers-test.js
+++ b/visitors/__tests__/es7-rest-property-helpers-test.js
@@ -18,23 +18,22 @@ describe('es7-rest-property-visitors', function() {
     visitors = require('../es6-destructuring-visitors').visitorList;
   });
 
-  function transform(code) {
-    var lines = Array.prototype.join.call(arguments, '\n');
-    return transformFn(visitors, lines).code;
+  function transform(lines, opts) {
+    return transformFn(visitors, lines.join('\n'), opts).code;
   }
 
   // Semantic tests.
 
   it('picks off remaining properties from an object', function() {
-    var code = transform(
+    var code = transform([
       '({ x, y, ...z } = { x: 1, y: 2, a: 3, b: 4 });',
       '([ x, y, z ]);'
-    );
+    ]);
     expect(eval(code)).toEqual([1, 2, { a: 3, b: 4 }]);
   });
 
   it('picks off remaining properties from a nested object', function() {
-    var code = transform(
+    var code = transform([
       'var complex = {',
       '  x: { a: 1, b: 2, c: 3 },',
       '  y: [4, 5, 6]',
@@ -44,49 +43,59 @@ describe('es7-rest-property-visitors', function() {
       '  y: [y0, ...y12]',
       '} = complex;',
       '([ xa, xbc, y0, y12 ]);'
-    );
+    ]);
     expect(eval(code)).toEqual([ 1, { b: 2, c: 3 }, 4, [5, 6] ]);
   });
 
   it('only extracts own properties', function() {
-    var code = transform(
+    var code = transform([
       'var obj = Object.create({ x: 1 });',
       'obj.y = 2;',
       '({ ...y } = obj);',
       '(y);'
-    );
+    ]);
+    expect(eval(code)).toEqual({ y: 2 });
+  });
+
+  it('only extracts own properties (polyfilled)', function() {
+    var code = transform([
+      'var obj = Object.create({ x: 1 });',
+      'obj.y = 2;',
+      '({ ...y } = obj);',
+      '(y);'
+    ], {polyfilled: true});
     expect(eval(code)).toEqual({ y: 2 });
   });
 
   it('only extracts own properties, except when they are explicit', function() {
-    var code = transform(
+    var code = transform([
       'var obj = Object.create({ x: 1, y: 2 });',
       'obj.z = 3;',
       '({ y, ...z } = obj);',
       '([ y, z ]);'
-    );
+    ]);
     expect(eval(code)).toEqual([ 2, { z: 3 } ]);
   });
 
   it('avoids passing extra properties when they are picked off', function() {
-    var code = transform(
+    var code = transform([
       'function base({ a, b, x }) { return [ a, b, x ]; }',
       'function wrapper({ x, y, ...restConfig }) {',
       '  return base(restConfig);',
       '}',
       'wrapper({ x: 1, y: 2, a: 3, b: 4 });'
-    );
+    ]);
     expect(eval(code)).toEqual([ 3, 4, undefined ]);
   });
 
   // Syntax tests.
 
   it('throws on leading rest properties', function () {
-    expect(() => transform('({ ...x, y, z } = obj)')).toThrow();
+    expect(() => transform(['({ ...x, y, z } = obj)'])).toThrow();
   });
 
   it('throws on multiple rest properties', function () {
-    expect(() => transform('({ x, ...y, ...z } = obj)')).toThrow();
+    expect(() => transform(['({ x, ...y, ...z } = obj)'])).toThrow();
   });
 
   // TODO: Ideally identifier reuse should fail to transform

--- a/visitors/es6-class-visitors.js
+++ b/visitors/es6-class-visitors.js
@@ -342,12 +342,7 @@ function _renderClassBody(traverse, node, path, state) {
       declareIdentInLocalScope(keyName, initScopeMetadata(node), state);
     }
     utils.append(
-      'for(' + keyNameDeclarator + keyName + ' in ' + superClass.name + '){' +
-        'if(' + superClass.name + '.hasOwnProperty(' + keyName + ')){' +
-          className + '[' + keyName + ']=' +
-            superClass.name + '[' + keyName + '];' +
-        '}' +
-      '}',
+      'Object.assign(' + className + ',' + superClass.name + ');',
       state
     );
 

--- a/visitors/es6-class-visitors.js
+++ b/visitors/es6-class-visitors.js
@@ -335,16 +335,28 @@ function _renderClassBody(traverse, node, path, state) {
       );
     }
 
-    var keyName = superClass.name + '____Key';
-    var keyNameDeclarator = '';
-    if (!utils.identWithinLexicalScope(keyName, state)) {
-      keyNameDeclarator = 'var ';
-      declareIdentInLocalScope(keyName, initScopeMetadata(node), state);
+    if (state.g.opts.polyfilled) {
+      utils.append(
+        'Object.assign(' + className + ',' + superClass.name + ');',
+        state
+      );
+    } else {
+      var keyName = superClass.name + '____Key';
+      var keyNameDeclarator = '';
+      if (!utils.identWithinLexicalScope(keyName, state)) {
+        keyNameDeclarator = 'var ';
+        declareIdentInLocalScope(keyName, initScopeMetadata(node), state);
+      }
+      utils.append(
+        'for(' + keyNameDeclarator + keyName + ' in ' + superClass.name + '){' +
+          'if(' + superClass.name + '.hasOwnProperty(' + keyName + ')){' +
+            className + '[' + keyName + ']=' +
+              superClass.name + '[' + keyName + '];' +
+          '}' +
+        '}',
+        state
+      );
     }
-    utils.append(
-      'Object.assign(' + className + ',' + superClass.name + ');',
-      state
-    );
 
     var superProtoIdentStr = SUPER_PROTO_IDENT_PREFIX + superClass.name;
     if (!utils.identWithinLexicalScope(superProtoIdentStr, state)) {

--- a/visitors/es6-destructuring-visitors.js
+++ b/visitors/es6-destructuring-visitors.js
@@ -101,7 +101,8 @@ function getDestructuredComponents(node, state) {
     if (item.type === Syntax.SpreadProperty) {
       var restExpression = restPropertyHelpers.renderRestExpression(
         utils.getTempVar(tmpIndex),
-        patternItems
+        patternItems,
+        state.g.opts.polyfilled
       );
       components.push(item.argument.name + '=' + restExpression);
       continue;

--- a/visitors/es7-rest-property-helpers.js
+++ b/visitors/es7-rest-property-helpers.js
@@ -59,17 +59,18 @@ function getRestFunctionCall(source, exclusion) {
   return restFunction + '(' + source + ',' + exclusion + ')';
 }
 
-function getSimpleShallowCopy(accessorExpression) {
-  // This could be faster with 'Object.assign({}, ' + accessorExpression + ')'
-  // but to unify code paths and avoid a ES6 dependency we use the same
-  // helper as for the exclusion case.
-  return getRestFunctionCall(accessorExpression, '{}');
+function getSimpleShallowCopy(accessorExpression, polyfilled) {
+  if (polyfilled) {
+    return 'Object.assign({}, ' + accessorExpression + ')';
+  } else {
+    return getRestFunctionCall(accessorExpression, '{}');
+  }
 }
 
-function renderRestExpression(accessorExpression, excludedProperties) {
+function renderRestExpression(accessorExpression, excludedProperties, polyfilled) {
   var excludedNames = getPropertyNames(excludedProperties);
   if (!excludedNames.length) {
-    return getSimpleShallowCopy(accessorExpression);
+    return getSimpleShallowCopy(accessorExpression, polyfilled);
   }
   return getRestFunctionCall(
     accessorExpression,


### PR DESCRIPTION
This PR changes the `class` creation helper so it copies inherited static props with `Object.assign` instead of a `for/in/hasOwnProperty` loop. It saves around ~70ish characters for every class. Now that [React ES6 classes](http://facebook.github.io/react/blog/2015/01/27/react-v0.13.0-beta-1.html#plain-javascript-classes) are a thing, these savings will quickly add up.

This change will require users to polyfill `Object.assign`. But since the [spread visitor](https://github.com/facebook/jstransform/blob/2524d79c684188ad530e3b50b3aaabcf4c53df90/visitors/es7-spread-property-visitors.js) already assumes that `Object.assign` exists, eh.