### PR TITLE
[RFC] Add option to use Object.assign instead of for-in loop in class transform

### DIFF
--- a/visitors/__tests__/es6-class-visitors-test.js
+++ b/visitors/__tests__/es6-class-visitors-test.js
@@ -186,6 +186,30 @@ describe('es6-classes', function() {
         expect(transform(code)).toBe(expected);
       });
 
+      it('uses Object.assign if the option is specified', function() {
+        var code = [
+          'class Foo extends Bar {}'
+        ].join('\n');
+
+        var expected = [
+          'Object.assign(Foo, Bar);' +
+          'var ____SuperProtoOfBar=' +
+            'Bar===null' +
+              '?null:' +
+              'Bar.prototype;' +
+          'Foo.prototype=Object.create(____SuperProtoOfBar);' +
+          'Foo.prototype.constructor=Foo;' +
+          'Foo.__superConstructor__=Bar;' +
+          'function Foo(){' +
+          '"use strict";if(Bar!==null){Bar.apply(this,arguments);}' +
+          '}'
+        ].join('\n');
+
+        expect(transform(code, {
+          useObjectAssign: true,
+        })).toBe(expected);
+      });
+
       it('preserves lines with inheritance from expression', function() {
         var code = [
           'class Foo extends mixin(Bar, Baz) {',

--- a/visitors/es6-class-visitors.js
+++ b/visitors/es6-class-visitors.js
@@ -341,15 +341,23 @@ function _renderClassBody(traverse, node, path, state) {
       keyNameDeclarator = 'var ';
       declareIdentInLocalScope(keyName, initScopeMetadata(node), state);
     }
-    utils.append(
-      'for(' + keyNameDeclarator + keyName + ' in ' + superClass.name + '){' +
-        'if(' + superClass.name + '.hasOwnProperty(' + keyName + ')){' +
-          className + '[' + keyName + ']=' +
-            superClass.name + '[' + keyName + '];' +
-        '}' +
-      '}',
-      state
-    );
+
+    if (state.g.opts.useObjectAssign) {
+      utils.append(
+        'Object.assign(' + className + ', ' + superClass.name + ');',
+        state
+      );
+    } else {
+      utils.append(
+        'for(' + keyNameDeclarator + keyName + ' in ' + superClass.name + '){' +
+          'if(' + superClass.name + '.hasOwnProperty(' + keyName + ')){' +
+            className + '[' + keyName + ']=' +
+              superClass.name + '[' + keyName + '];' +
+          '}' +
+        '}',
+        state
+      );
+    }
 
     var superProtoIdentStr = SUPER_PROTO_IDENT_PREFIX + superClass.name;
     if (!utils.identWithinLexicalScope(superProtoIdentStr, state)) {


### PR DESCRIPTION
This allows us to reduce the number of bytes a single class is using when using the class transform + it allows us to use optimized native `Object.assign` implementations.