### PR TITLE
Fix call spread transform with temp vars

### DIFF
--- a/visitors/__tests__/es6-rest-param-visitors-test.js
+++ b/visitors/__tests__/es6-rest-param-visitors-test.js
@@ -35,12 +35,14 @@ describe('es6-rest-param-visitors', () => {
     arrowFuncVisitors = require('../es6-arrow-function-visitors').visitorList;
     classVisitors = require('../es6-class-visitors').visitorList;
     restParamVisitors = require('../es6-rest-param-visitors').visitorList;
+    callSpreadVisitors = require('../es6-call-spread-visitors').visitorList;
     transformFn = require('../../src/jstransform').transform;
 
     visitorSet =
       arrowFuncVisitors
         .concat(classVisitors)
-        .concat(restParamVisitors);
+        .concat(restParamVisitors)
+        .concat(callSpreadVisitors);
   });
 
   function transform(code) {
@@ -123,6 +125,22 @@ describe('es6-rest-param-visitors', () => {
       eval(code);
 
       expect(test()).toBe(true);
+    });
+
+    it('should work with temp var injections', () => {
+      // Use call spread as example. It injects a temp var into function scope.
+      var code = transform([
+        'function test(bar, ...args) {',
+        '  return bar(...args);',
+        '}'
+      ].join('\n'));
+
+      eval(code);
+
+      var fn = function() {
+        return Array.prototype.slice.call(arguments).map(i => i + 1);
+      };
+      expect(test(fn, 1, 2, 3)).toEqual([2, 3, 4]);
     });
   });
 

--- a/visitors/es6-rest-param-visitors.js
+++ b/visitors/es6-rest-param-visitors.js
@@ -63,6 +63,7 @@ function visitFunctionParamsWithRestParam(traverse, node, path, state) {
     utils.catchup(node.rest.range[0] - 3, state);
   }
   utils.catchupWhiteSpace(node.rest.range[1], state);
+  utils.catchup(node.body.range[0], state);
 
   path.unshift(node);
   traverse(node.body, path, state);


### PR DESCRIPTION
The root of the problem is that we never caught up to the beginning of
the function body. So our buffer never included the opening brace when
we stopped visiting the fn params. This works out most of the time
because we eventually catchup. But when we insert temp vars we assume
the buffer is caught up to the function body. But we didn't do that so
temp vars were inserted at the wrong place.

Fixes #88. cc@jeffmo @DmitrySoshnikov