### PR TITLE
Added failing test for concatenating numeric expressions using template strings

### DIFF
--- a/visitors/__tests__/es6-template-visitors-test.js
+++ b/visitors/__tests__/es6-template-visitors-test.js
@@ -185,6 +185,13 @@ describe('ES6 Template Visitor', function() {
     expectEval("`foo\n${bar}\nbaz`", 'foo\nabc\nbaz', 'var bar = "abc";');
   });
 
+  it('should handle numeric expressions', function() {
+    expectEval("`foo${1}bar${2}`", 'foo1bar2');
+    expectEval("`foo${1}${2}bar`", 'foo12bar');
+    expectEval("`${1}${2}foo`", '12foo');
+    expectEval("`${1}${2}`", '12');
+  });
+
   it('should canonicalize line endings', function() {
     // TODO: should this be '("foo\\nbar"\r\n)' to maintain the number of lines
     // for editors that break on \r\n? I don't think we care in the transformed


### PR DESCRIPTION
I noticed some strange behavior when I was using ES6 template strings in my React code. As I was printing a year plus week, the values would be summed together before being output instead of concatenating them as strings. E.g. `` `${ 2014 }${ 12 }` === 2026`` instead of `` `${ 2014 }${ 12 }` === "201412"``

I only created a failing test case in this pull request, since I haven't really grasped the workings of jstransform. The expected behavior in the tests have been verified in Chrome and Firefox.

Hope you can help me out!