### PR TITLE
Ensure Template literals always concat, never sum

### DIFF
--- a/visitors/__tests__/es6-template-visitors-test.js
+++ b/visitors/__tests__/es6-template-visitors-test.js
@@ -85,20 +85,21 @@ describe('ES6 Template Visitor', function() {
 
   it('should transform simple substitutions', function() {
     expectTransform('`foo ${bar}`', '("foo " + bar)');
-    expectTransform('`${foo} bar`', '(foo + " bar")');
-    expectTransform('`${foo} ${bar}`', '(foo + " " + bar)');
-    expectTransform('`${foo}${bar}`', '(foo + bar)');
+    expectTransform('`${foo} bar`', '("" + foo + " bar")');
+    expectTransform('`${foo} ${bar}`', '("" + foo + " " + bar)');
+    expectTransform('`${foo}${bar}`', '("" + foo + bar)');
   });
 
   it('should transform expressions', function() {
     expectTransform('`foo ${bar()}`', '("foo " + bar())');
     expectTransform('`foo ${bar.baz}`', '("foo " + bar.baz)');
     expectTransform('`foo ${bar + 5}`', '("foo " + (bar + 5))');
-    expectTransform('`${foo + 5} bar`', '((foo + 5) + " bar")');
-    expectTransform('`${foo + 5} ${bar}`', '((foo + 5) + " " + bar)');
+    expectTransform('`${foo + 5} bar`', '("" + (foo + 5) + " bar")');
+    expectTransform('`${foo + 5} ${bar}`', '("" + (foo + 5) + " " + bar)');
     expectTransform(
       '`${(function(b) {alert(4);})(a)}`',
-      '((function(b) {alert(4);})(a))');
+      '("" + (function(b) {alert(4);})(a))');
+    expectTransform("`${4 + 5}`", '("" + (4 + 5))');
   });
 
   it('should transform tags with simple templates', function() {
@@ -191,6 +192,24 @@ describe('ES6 Template Visitor', function() {
     expectEval("`${1}${2}foo`", '12foo');
     expectEval("`${1}${2}`", '12');
   });
+
+  it('should handle primitive literals', function() {
+    expectTransform("`${42}`", '("" + 42)');
+    expectEval("`${42}`", '42');
+
+    expectTransform("`${'42'}`", '("" + \'42\')');
+    expectEval("`${'42'}`", '42');
+
+    expectTransform("`${true}`", '("" + true)');
+    expectEval("`${true}`", 'true');
+
+    expectTransform("`${null}`", '("" + null)');
+    expectEval("`${null}`", 'null');
+
+    // undefined is actually an Identifier but it falls into the same category
+    expectTransform("`${undefined}`", '("" + undefined)');
+    expectEval("`${undefined}`", 'undefined');
+  }),
 
   it('should canonicalize line endings', function() {
     // TODO: should this be '("foo\\nbar"\r\n)' to maintain the number of lines

--- a/visitors/__tests__/es6-template-visitors-test.js
+++ b/visitors/__tests__/es6-template-visitors-test.js
@@ -185,6 +185,13 @@ describe('ES6 Template Visitor', function() {
     expectEval("`foo\n${bar}\nbaz`", 'foo\nabc\nbaz', 'var bar = "abc";');
   });
 
+  it('should handle numeric expressions', function() {
+    expectEval("`foo${1}bar${2}`", 'foo1bar2');
+    expectEval("`foo${1}${2}bar`", 'foo12bar');
+    expectEval("`${1}${2}foo`", '12foo');
+    expectEval("`${1}${2}`", '12');
+  });
+
   it('should canonicalize line endings', function() {
     // TODO: should this be '("foo\\nbar"\r\n)' to maintain the number of lines
     // for editors that break on \r\n? I don't think we care in the transformed

--- a/visitors/es6-template-visitors.js
+++ b/visitors/es6-template-visitors.js
@@ -46,6 +46,9 @@ function visitTemplateLiteral(traverse, node, path, state) {
       // Concatenat adjacent substitutions, e.g. `${x}${y}`. Empty templates
       // appear before the first and after the last element - nothing to add in
       // those cases.
+      if (ii === 0) {
+        utils.append('"" + ', state);
+      }
       if (ii > 0 && !templateElement.tail) {
         // + between substitution and substitution
         utils.append(' + ', state);
@@ -56,6 +59,7 @@ function visitTemplateLiteral(traverse, node, path, state) {
     if (!templateElement.tail) {
       var substitution = node.expressions[ii];
       if (substitution.type === Syntax.Identifier ||
+          substitution.type === Syntax.Literal ||
           substitution.type === Syntax.MemberExpression ||
           substitution.type === Syntax.CallExpression) {
         utils.catchup(substitution.range[1], state);


### PR DESCRIPTION
Pulls in the test from #92 (CLA was signed there) and then I fixed it and added some more tests.

The general idea was to always ensure that we'll have a string. We probably only needed the `"" + ` at the beginning ~~but I also made it insert between substitutions~~.

The other piece here was removing parentheses from around literals so they get treated the same as identifiers. AFAICT there wasn't a good reason to do it how we had it.

cc @DmitrySoshnikov @jeffmo @fkling 