### PR TITLE
Fix spread arguments

### DIFF
--- a/visitors/__tests__/es6-call-spread-visitors-test.js
+++ b/visitors/__tests__/es6-call-spread-visitors-test.js
@@ -51,6 +51,11 @@ describe('es6-call-spread-visitors', function() {
       .toEqual('new (Function.prototype.bind.apply(Set, [null, 1, 2].concat(list)))');
   });
 
+  it('should spread `arguments` while creating new instances', function() {
+    expect(transform('function fn(){ new Set(...arguments); }'))
+      .toEqual('function fn(){ new (Function.prototype.bind.apply(Set, [null].concat(Array.prototype.slice.call(arguments)))); }');
+  });
+
   it('should create temporary variables when necessary in program scope', function() {
     expect(transform('foo().bar(arg1, arg2, ...more)'))
       .toEqual('var $__0;($__0 = foo()).bar.apply($__0, [arg1, arg2].concat(more))');

--- a/visitors/es6-call-spread-visitors.js
+++ b/visitors/es6-call-spread-visitors.js
@@ -80,7 +80,13 @@ function visitCallSpread(traverse, node, path, state) {
       }
     }
     utils.append('].concat(', state);
-    process(traverse, spread.argument, path, state);
+    if (spread.argument.name === 'arguments') {
+      // Input  = function fn() { new Set(...arguments) }
+      // Output = new (Function.prototype.bind.apply(Set, [null].concat(Array.prototype.slice.call(arguments))))
+      utils.append('Array.prototype.slice.call(arguments)', state);
+    } else {
+      process(traverse, spread.argument, path, state);
+    }
     utils.append(')', state);
   } else {
     process(traverse, spread.argument, path, state);


### PR DESCRIPTION
While trying to simplify React's [PooledClass.js](https://github.com/facebook/react/tree/master/src/utils/PooledClass.js) and changing it from multiple Poolers to just one that uses a spread operator, I noticed that `return new Klass(...arguments);` is  wrongly transformed into `return new (Function.prototype.bind.apply(Klass, [null].concat(arguments)));`. The problem here is that `concat` only works in the expected way with Arrays, not Array-like Objects, like what `arguments` is.

This PR fixes that issue and transforms

```
return new Klass(...arguments);
```

into

```
return new (Function.prototype.bind.apply(Klass, [null].concat(Array.prototype.slice.call(arguments))));
```