### PR TITLE
Remove trailing array comma in es6-call-spread-visitors.js

### DIFF
--- a/visitors/es6-call-spread-visitors.js
+++ b/visitors/es6-call-spread-visitors.js
@@ -108,5 +108,5 @@ visitCallSpread.test = function(node, path, state) {
 };
 
 exports.visitorList = [
-  visitCallSpread,
+  visitCallSpread
 ];


### PR DESCRIPTION
Makes it work in IE8 and consistent with other visitors.