### PR TITLE
jsx helper, return " " instead of \' \' for multiline literals

### DIFF
--- a/visitors/__tests__/jsx-helpers-test.js
+++ b/visitors/__tests__/jsx-helpers-test.js
@@ -80,7 +80,7 @@ describe('jsx', function() {
       true);
 
     expect(state.g.buffer).toEqual(
-      '"  sdfsdfsdf" + \' \' +\n' +
+      '"  sdfsdfsdf" + " " +\n' +
       '  "sdlkfjsdfljs"\n' +
       '   ');
   });
@@ -93,7 +93,7 @@ describe('jsx', function() {
       false);
 
     expect(state.g.buffer).toEqual(
-      '"  sdfsdfsdf" + \' \' +\n' +
+      '"  sdfsdfsdf" + " " +\n' +
       '  "sdlkfjsdfljs", \n' +
       '   ');
   });

--- a/visitors/jsx-helpers.js
+++ b/visitors/jsx-helpers.js
@@ -76,7 +76,7 @@ function renderJSXLiteral(object, isLast, state, start, end) {
     if (trimmedLine || isLastNonEmptyLine) {
       utils.append(
         JSON.stringify(trimmedLine) +
-        (!isLastNonEmptyLine ? ' + \' \' +' : ''),
+        (!isLastNonEmptyLine ? ' + " " +' : ''),
         state);
 
       if (isLastNonEmptyLine) {


### PR DESCRIPTION
Multiline literals such as

    line one
    line two

are return as

    "line one" + ' ' +
    "line two"

this breaks our jsxlinting as there is both ' and ".  It'd be better if " was used consistently for wrapping literals.