### PR TITLE
Fix sourceMap error

### DIFF
--- a/src/simple.js
+++ b/src/simple.js
@@ -114,7 +114,7 @@ function transform(code, options) {
   var sourceMap;
   if (result.sourceMap) {
     sourceMap = result.sourceMap.toJSON();
-    sourceMap.sources = transformOptions.filename;
+    sourceMap.sources = [transformOptions.filename];
     sourceMap.sourcesContent = [code];
   }
 
@@ -163,4 +163,3 @@ module.exports = {
   transformFile: transformFile,
   transformFileSync: transformFileSync
 };
-


### PR DESCRIPTION
### code

```javascript
var SourceMapConsumer = require('source-map').SourceMapConsumer;
var jstransform = require('jstransform/simple');

var code = "console.log('test');";
var result = jstransform.transform(code, {
  sourceMap: true
});
var smc = new SourceMapConsumer(result.sourceMap);
```

### error

```
TypeError: undefined is not a function
  at SourceMapConsumer.BasicSourceMapConsumer (node-test/node_modules/source-map/lib/source-map/source-map-consumer.js:311:23)
  at new SourceMapConsumer (node-test/node_modules/source-map/lib/source-map/source-map-consumer.js:26:9)
  at Object.<anonymous> (node-test/jstransform.coffee:6:11)
  at Object.<anonymous> (node-test/jstransform.coffee:1:1)
  at Module._compile (module.js:460:26)
```