### PR TITLE
Propose: React JSX module syntax

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,69 @@
 # JSTransform [![Build Status](https://travis-ci.org/facebook/jstransform.svg?branch=master)](https://travis-ci.org/facebook/jstransform)
 
+This is a fork for propose JSX modules like this:
+
+```html
+<!DOCTYPE JSX>
+
+<ReactClass name="Timer">
+  <div>Seconds Elapsed: {secondsElapsed}</div>
+
+  <script>
+    function getInitialState() {
+      return { secondsElapsed = 0 };
+    }
+    function tick(){
+      this.setState({secondsElapsed: secondsElapsed + 1});
+    }
+    function componentDidMount() {
+      this.interval = setInterval(this.tick, 1000);
+    }
+    function componentWillUnmount() {
+      clearInterval(this.interval);
+    }
+  </script>
+</ReactClass>
+
+React.render(<Timer />, mountNode);
+```
+
+=== 
+Why
+* Better look and feel (I think so)
+* Better compatibility with IDE's, linters...
+* 100% compatible with React legacy code
+
+=== 
+Done
+* Enabling tag `<!DOCTYPE JSX>`. I don't like it, and maybe it's not necessary because JSXModule just works when JSX is as statement (not expression), but i'm worry with legacy code.
+* Parser for script, link and style tags.
+* visitors for jstransform
+* visitors for react
+* the code above works well
+
+=== 
+Todo
+* avoid this from all know (class internals) identifiers
+> how detect setState when invoking methods? (like push, shift, splice...)
+* Transform css script into javascript objects.
+> Rename css classes to allow local scope
+> autoprex vendor tags
+** I18N
+** Docs
+
+===
+Repositories:
+https://github.com/thr0w/esprima
+https://github.com/thr0w/jstransform
+https://github.com/thr0w/react
+
+===
+References:
+* https://muut.com/riotjs/
+* https://github.com/undoZen/htmlxify
+
+===
+
 A simple utility for pluggable JS syntax transforms using the esprima parser.
 
 * Makes it simple to write and plug-in syntax transformations

--- a/package.json
+++ b/package.json
@@ -22,8 +22,8 @@
   ],
   "dependencies": {
     "base62": "^1.1.0",
-    "esprima-fb": "https://codeload.github.com/thr0w/esprima/legacy.tar.gz/JSXModule",
     "commoner": "^0.10.1",
+    "esprima-fb": "https://codeload.github.com/thr0w/esprima/legacy.tar.gz/JSXModule",
     "object-assign": "^2.0.0",
     "source-map": "^0.4.2"
   },

--- a/package.json
+++ b/package.json
@@ -22,8 +22,8 @@
   ],
   "dependencies": {
     "base62": "^1.1.0",
-    "commoner": "^0.10.1",
     "esprima-fb": "https://codeload.github.com/thr0w/esprima/legacy.tar.gz/JSXModule",
+    "commoner": "^0.10.1",
     "object-assign": "^2.0.0",
     "source-map": "^0.4.2"
   },

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
   "dependencies": {
     "base62": "^1.1.0",
     "commoner": "^0.10.1",
-    "esprima-fb": "^15001.1.0-dev-harmony-fb",
+    "esprima-fb": "https://codeload.github.com/thr0w/esprima/legacy.tar.gz/JSXModule",
     "object-assign": "^2.0.0",
     "source-map": "^0.4.2"
   },

--- a/visitors/__tests__/react-jsx-module-test.js
+++ b/visitors/__tests__/react-jsx-module-test.js
@@ -1,0 +1,79 @@
+/**
+ * Copyright 2013-present, Facebook, Inc.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree. An additional grant
+ * of patent rights can be found in the PATENTS file in the same directory.
+ *
+ * @emails react-core
+ */
+'use strict';
+
+require('mock-modules').autoMockOff();
+
+var transformFn = require('jstransform').transform;
+var visitors = require('../react-jsx-module-visitors').visitorList;
+
+function transform(code) {
+  return transformFn(visitors, code, {sourceType: 'module'});
+}
+
+describe('react jsx module', function() {
+
+  it('should transpile to createClass and export module as default', function() {
+
+    var code = [
+      '<!doctype jsx>',
+      '<ReactClass name="Whateva" export="default">',
+      '  <div>X</div>',
+      '</ReactClass>'
+    ].join('\n');
+
+    var expected = [
+      '"use strict";',
+      'var Whateva = React.createClass({',
+      '  displayName: "Whateva",',
+      '  render: function() {',
+      '    return <div>X</div>;',
+      '  }',
+      '});',
+      'export default Whateva;'
+    ].join('\n');
+
+    expect(transform(code).code).toEqual(expected);
+  });
+
+  it('should transpile to createClass and export modules', function() {
+    var code = [
+      '<!doctype jsx>',
+      '<ReactClass name="Whateva">',
+      '  <div>X</div>',
+      '</ReactClass>',
+      '<ReactClass name="Whateva2">',
+      '  <div>Y</div>',
+      '</ReactClass>'
+    ].join('\n');
+
+    var expected = [
+      '"use strict";',
+      'var Whateva = React.createClass({',
+      '  displayName: "Whateva",',
+      '  render: function() {',
+      '    return <div>X</div>;',
+      '  }',
+      '});',
+      'export Whateva;',
+      'var Whateva2 = React.createClass({',
+      '  displayName: "Whateva2",',
+      '  render: function() {',
+      '    return <div>Y</div>;',
+      '  }',
+      '});',
+      'export Whateva2;',
+    ].join('\n');
+
+    expect(transform(code).code).toEqual(expected);
+  });
+
+});

--- a/visitors/index.js
+++ b/visitors/index.js
@@ -47,7 +47,7 @@ var transformVisitors = {
   'es7-trailing-comma': es7TrailingComma.visitorList,
   'react-display-name': reactDisplayName.visitorList,
   'react-jsx': reactJSX.visitorList,
-  'react-jsx': reactJSXModule.visitorList,
+  'react-jsx-module': reactJSXModule.visitorList,
   'reserved-words': reservedWords.visitorList,
   'trailing-comma': trailingComma.visitorList,
   'undefined-to-void-0': undefinedToVoid0.visitorList

--- a/visitors/index.js
+++ b/visitors/index.js
@@ -25,6 +25,7 @@ var es6Template = require('./es6-template-visitors');
 var es7SpreadProperty = require('./es7-spread-property-visitors');
 var es7TrailingComma = require('./es7-trailing-comma-visitors');
 var reactDisplayName = require('./react-display-name-visitors');
+var reactJSXModule = require('./react-jsx-module-visitors');
 var reactJSX = require('./react-jsx-visitors');
 var reservedWords = require('./reserved-words-visitors');
 var trailingComma = require('./trailing-comma-visitors');
@@ -46,6 +47,7 @@ var transformVisitors = {
   'es7-trailing-comma': es7TrailingComma.visitorList,
   'react-display-name': reactDisplayName.visitorList,
   'react-jsx': reactJSX.visitorList,
+  'react-jsx': reactJSXModule.visitorList,
   'reserved-words': reservedWords.visitorList,
   'trailing-comma': trailingComma.visitorList,
   'undefined-to-void-0': undefinedToVoid0.visitorList
@@ -72,7 +74,8 @@ var transformSets = {
   ],
   'react': [
     'react-jsx',
-    'react-display-name'
+    'react-display-name',
+    'react-jsx-module'
   ],
   'target:es3': [
     'reserved-words',
@@ -106,6 +109,7 @@ var transformRunOrder = [
   'trailing-comma',
   'es7-trailing-comma',
   'react-jsx',
+  'react-jsx-module',
   'react-display-name',
   'undefined-to-void-0'
 ];

--- a/visitors/react-jsx-module-visitors.js
+++ b/visitors/react-jsx-module-visitors.js
@@ -106,100 +106,21 @@ function visitReactJSXClassDeclaration(traverse, node, path, state) {
     }
   });
 
-  if (error)
-     throw new Error(error +'. (line: ' +
-       node.loc.start.line + ', col: ' + node.loc.start.column + ')'
-     );
-  if (export_class === 'default')
+  if (error) {
+    throw new Error(error +'. (line: ' +
+      node.loc.start.line + ', col: ' + node.loc.start.column + ')'
+    );
+  }
+  if (export_class === 'default') {
     utils.append('\nexport default '+state.className.name+';', state);
-  else if (export_class === true)
+  }
+  else if (export_class === true) {
     utils.append('\nexport '+state.className.name+';', state);
-  //utils.catchupWhiteSpace(node.range[1], state);
-  //utils.catchupWhiteSpace(node.range[1], state);
-
-  //_renderClassBody(traverse, node, path, state);
+  }
 
   return false;
 
 }
-
-/**
- * @param {function} traverse
- * @param {object} node
- * @param {array} path
- * @param {object} state
- */
-function _renderClassBody(traverse, node, path, state) {
-  var className = state.className;
-
-//  utils.append(
-//    'var ' + superClass.name + '=' + superClass.expression + ';',
-//    state
-//  );
-//
-//
-//    var keyName = superClass.name + '____Key';
-//    var keyNameDeclarator = '';
-//    if (!utils.identWithinLexicalScope(keyName, state)) {
-//      keyNameDeclarator = 'var ';
-//      declareIdentInLocalScope(keyName, initScopeMetadata(node), state);
-//    }
-//    utils.append(
-//      'for(' + keyNameDeclarator + keyName + ' in ' + superClass.name + '){' +
-//        'if(' + superClass.name + '.hasOwnProperty(' + keyName + ')){' +
-//          className + '[' + keyName + ']=' +
-//            superClass.name + '[' + keyName + '];' +
-//        '}' +
-//      '}',
-//      state
-//    );
-//
-//    var superProtoIdentStr = SUPER_PROTO_IDENT_PREFIX + superClass.name;
-//    if (!utils.identWithinLexicalScope(superProtoIdentStr, state)) {
-//      utils.append(
-//        'var ' + superProtoIdentStr + '=' + superClass.name + '===null?' +
-//        'null:' + superClass.name + '.prototype;',
-//        state
-//      );
-//      declareIdentInLocalScope(superProtoIdentStr, initScopeMetadata(node), state);
-//    }
-//
-//    utils.append(
-//      className + '.prototype=Object.create(' + superProtoIdentStr + ');',
-//      state
-//    );
-//    utils.append(
-//      className + '.prototype.constructor=' + className + ';',
-//      state
-//    );
-//    utils.append(
-//      className + '.__superConstructor__=' + superClass.name + ';',
-//      state
-//    );
-//  }
-//
-//  // If there's no constructor method specified in the class body, create an
-//  // empty constructor function at the top (same line as the class keyword)
-//  if (!node.body.body.filter(_isConstructorMethod).pop()) {
-//    utils.append('function ' + className + '(){', state);
-//    if (!state.scopeIsStrict) {
-//      utils.append('"use strict";', state);
-//    }
-//    if (superClass.name) {
-//      utils.append(
-//        'if(' + superClass.name + '!==null){' +
-//        superClass.name + '.apply(this,arguments);}',
-//        state
-//      );
-//    }
-//    utils.append('}', state);
-//  }
-//
-//  utils.move(node.body.range[0] + '{'.length, state);
-//  traverse(node.body, path, state);
-//  utils.catchupWhiteSpace(node.range[1], state);
-}
-
 
 visitReactJSXModuleDeclaration.test = function(node, path, state) {
   return node.type === Syntax.JSXModuleDeclaration;

--- a/visitors/react-jsx-module-visitors.js
+++ b/visitors/react-jsx-module-visitors.js
@@ -1,0 +1,215 @@
+/**
+ * Copyright 2013-present, Facebook, Inc.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree. An additional grant
+ * of patent rights can be found in the PATENTS file in the same directory.
+ */
+/*global exports:true*/
+'use strict';
+
+var Syntax = require('esprima-fb').Syntax;
+var utils = require('../src/utils');
+
+/**
+ * Transforms the following:
+ *
+ * <!doctype jsx>
+ * <ReactClass MyComponent>'
+ *   <ELEMENTS...>
+ *   <SCRIPTS...>
+ * </ReactClass MyComponent>
+ *
+ * into:
+ *
+ * var MyComponent = React.createClass({
+ *    displayName: 'MyComponent',
+ *    render: ()=>ELEMENTS,
+ *    TRANSPILED SCRIPTS
+ * });
+ * export MyComponent;
+ *
+ */
+
+function visitReactJSXModuleDeclaration(traverse, node, path, state) {
+
+  utils.append('"use strict";', state);
+  traverse(node.imports, path, state);
+  utils.move(node.range[1], state);
+
+  return false;
+
+}
+
+/**
+ * Transforms the following:
+ *
+ * <!doctype jsx>
+ * <ReactClass MyComponent>'
+ *   <ELEMENTS...>
+ *   <SCRIPTS...>
+ * </ReactClass MyComponent>
+ *
+ * into:
+ *
+ * var MyComponent = React.createClass({
+ *    displayName: 'MyComponent',
+ *    render: ()=>ELEMENTS,
+ *    TRANSPILED SCRIPTS
+ * });
+ * export MyComponent;
+ *
+ */
+function visitReactJSXClassDeclaration(traverse, node, path, state) {
+
+  state = utils.updateState(state, {
+    className: node.className
+  });
+
+  utils.append('var ' + state.className.name+ ' = React.createClass({', state);
+
+  utils.move(node.className.range[0], state);
+  utils.append('\n  displayName: "'+state.className.name+'",', state);
+
+  utils.append('\n  render: function() {\n    return ', state);
+
+  utils.move(node.render.range[0], state);
+  traverse(node.render, path, state);
+  utils.move(node.render.range[1], state);
+  utils.append(';\n  }', state);
+
+  utils.move(node.range[1], state);
+  utils.append('\n});', state);
+
+  var error, export_class=true;
+  node.attributes.forEach(function(attr) {
+    switch (attr.name.name) {
+    case 'export':
+       switch (attr.value.value) {
+       case 'false':
+         export_class = false;
+         break;
+       case 'default':
+         export_class = 'default';
+         break;
+       case 'true':
+         break;
+       default:
+         error = 'Invalid value for export attribute';
+         break;
+       }
+       break;
+    default:
+      error = 'Invalid attribute '+attr.name.name;
+      break;
+    }
+  });
+
+  if (error)
+     throw new Error(error +'. (line: ' +
+       node.loc.start.line + ', col: ' + node.loc.start.column + ')'
+     );
+  if (export_class === 'default')
+    utils.append('\nexport default '+state.className.name+';', state);
+  else if (export_class === true)
+    utils.append('\nexport '+state.className.name+';', state);
+  //utils.catchupWhiteSpace(node.range[1], state);
+  //utils.catchupWhiteSpace(node.range[1], state);
+
+  //_renderClassBody(traverse, node, path, state);
+
+  return false;
+
+}
+
+/**
+ * @param {function} traverse
+ * @param {object} node
+ * @param {array} path
+ * @param {object} state
+ */
+function _renderClassBody(traverse, node, path, state) {
+  var className = state.className;
+
+//  utils.append(
+//    'var ' + superClass.name + '=' + superClass.expression + ';',
+//    state
+//  );
+//
+//
+//    var keyName = superClass.name + '____Key';
+//    var keyNameDeclarator = '';
+//    if (!utils.identWithinLexicalScope(keyName, state)) {
+//      keyNameDeclarator = 'var ';
+//      declareIdentInLocalScope(keyName, initScopeMetadata(node), state);
+//    }
+//    utils.append(
+//      'for(' + keyNameDeclarator + keyName + ' in ' + superClass.name + '){' +
+//        'if(' + superClass.name + '.hasOwnProperty(' + keyName + ')){' +
+//          className + '[' + keyName + ']=' +
+//            superClass.name + '[' + keyName + '];' +
+//        '}' +
+//      '}',
+//      state
+//    );
+//
+//    var superProtoIdentStr = SUPER_PROTO_IDENT_PREFIX + superClass.name;
+//    if (!utils.identWithinLexicalScope(superProtoIdentStr, state)) {
+//      utils.append(
+//        'var ' + superProtoIdentStr + '=' + superClass.name + '===null?' +
+//        'null:' + superClass.name + '.prototype;',
+//        state
+//      );
+//      declareIdentInLocalScope(superProtoIdentStr, initScopeMetadata(node), state);
+//    }
+//
+//    utils.append(
+//      className + '.prototype=Object.create(' + superProtoIdentStr + ');',
+//      state
+//    );
+//    utils.append(
+//      className + '.prototype.constructor=' + className + ';',
+//      state
+//    );
+//    utils.append(
+//      className + '.__superConstructor__=' + superClass.name + ';',
+//      state
+//    );
+//  }
+//
+//  // If there's no constructor method specified in the class body, create an
+//  // empty constructor function at the top (same line as the class keyword)
+//  if (!node.body.body.filter(_isConstructorMethod).pop()) {
+//    utils.append('function ' + className + '(){', state);
+//    if (!state.scopeIsStrict) {
+//      utils.append('"use strict";', state);
+//    }
+//    if (superClass.name) {
+//      utils.append(
+//        'if(' + superClass.name + '!==null){' +
+//        superClass.name + '.apply(this,arguments);}',
+//        state
+//      );
+//    }
+//    utils.append('}', state);
+//  }
+//
+//  utils.move(node.body.range[0] + '{'.length, state);
+//  traverse(node.body, path, state);
+//  utils.catchupWhiteSpace(node.range[1], state);
+}
+
+
+visitReactJSXModuleDeclaration.test = function(node, path, state) {
+  return node.type === Syntax.JSXModuleDeclaration;
+};
+
+visitReactJSXClassDeclaration.test = function(node, path, state) {
+  return node.type === Syntax.JSXClassDeclaration && node.superClass.name === 'ReactClass';
+};
+
+exports.visitorList = [
+  visitReactJSXModuleDeclaration,
+  visitReactJSXClassDeclaration
+];


### PR DESCRIPTION
```html
<!DOCTYPE JSX>

<ReactClass name="Timer">
  <div>Seconds Elapsed: {secondsElapsed}</div>

  <script>
    function getInitialState() {
      return { secondsElapsed = 0 };
    }
    function tick(){
      this.setState({secondsElapsed: secondsElapsed + 1});
    }
    function componentDidMount() {
      this.interval = setInterval(this.tick, 1000);
    }
    function componentWillUnmount() {
      clearInterval(this.interval);
    }
  </script>
</ReactClass>

React.render(<Timer />, mountNode);
```

=== 
Why
* Better look and feel (I think so)
* Better compatibility with IDE's, linters...
* 100% compatible with React legacy code

=== 
Done
* Enabling tag `<!DOCTYPE JSX>`. I don't like it, and maybe it's not necessary because JSXModule just works when JSX is as statement (not expression), but i'm worry with legacy code.
* Parser for script, link and style tags.
* visitors for jstransform
* visitors for react
* the code above works well

=== 
Todo
* avoid this from all know (class internals) identifiers
> how detect setState when invoking methods? (like push, shift, splice...)
* Transform css script into javascript objects.
> Rename css classes to allow local scope
> autoprex vendor tags
** I18N
** Docs

===
Repositories:
https://github.com/thr0w/esprima
https://github.com/thr0w/jstransform
https://github.com/thr0w/react

===
References:
* https://muut.com/riotjs/
* https://github.com/undoZen/htmlxify
